### PR TITLE
Upgrade to PSR-4 autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,8 @@
         "symfony/validator": "^2.1 || ^3.0"
     },
     "autoload": {
-        "psr-0": {
+        "psr-4": {
             "Intaro\\CustomIndexBundle\\": ""
         }
-    },
-    "target-dir" : "Intaro/CustomIndexBundle"
+    }
 }


### PR DESCRIPTION
[PSR-0](http://www.php-fig.org/psr/psr-0/) is deprecated:

> **Deprecated** - As of 2014-10-21 PSR-0 has been marked as deprecated. [PSR-4](http://www.php-fig.org/psr/psr-4/) is now recommended as an alternative.