### PR TITLE
Indexes in an abstract class of a joined inheritance

### DIFF
--- a/Command/IndexUpdateCommand.php
+++ b/Command/IndexUpdateCommand.php
@@ -148,9 +148,16 @@ class IndexUpdateCommand extends Command
                 // create index using abstract parent
                 $parentsMeta = $this->searchParentsWithIndex($meta);
                 foreach ($parentsMeta as $parentMeta) {
+                    if ($meta->inheritanceType > ClassMetadata::INHERITANCE_TYPE_NONE &&
+                        $meta->inheritanceType < ClassMetadata::INHERITANCE_TYPE_TABLE_PER_CLASS
+                    ) {
+                        $tableName = $parentMeta->getTableName();
+                    } else {
+                        $tableName = $meta->getTableName();
+                    }
                     $indexesToResult(
                         $parentMeta,
-                        $meta->getTableName(),
+                        $tableName,
                         true
                     );
                 }

--- a/Command/IndexUpdateCommand.php
+++ b/Command/IndexUpdateCommand.php
@@ -148,8 +148,7 @@ class IndexUpdateCommand extends Command
                 // create index using abstract parent
                 $parentsMeta = $this->searchParentsWithIndex($meta);
                 foreach ($parentsMeta as $parentMeta) {
-                    if ($meta->inheritanceType > ClassMetadata::INHERITANCE_TYPE_NONE &&
-                        $meta->inheritanceType < ClassMetadata::INHERITANCE_TYPE_TABLE_PER_CLASS
+                    if ($meta->inheritanceType === ClassMetadata::INHERITANCE_TYPE_JOINED
                     ) {
                         $tableName = $parentMeta->getTableName();
                     } else {

--- a/Command/IndexUpdateCommand.php
+++ b/Command/IndexUpdateCommand.php
@@ -148,12 +148,12 @@ class IndexUpdateCommand extends Command
                 // create index using abstract parent
                 $parentsMeta = $this->searchParentsWithIndex($meta);
                 foreach ($parentsMeta as $parentMeta) {
-                    if ($meta->inheritanceType === ClassMetadata::INHERITANCE_TYPE_JOINED
-                    ) {
+                    if ($meta->inheritanceType === ClassMetadata::INHERITANCE_TYPE_JOINED) {
                         $tableName = $parentMeta->getTableName();
                     } else {
                         $tableName = $meta->getTableName();
                     }
+
                     $indexesToResult(
                         $parentMeta,
                         $tableName,


### PR DESCRIPTION
Properly sets table name in case the index is present in an abstract class of a Joined inheritance.

i.e.:

```
/**
 * Class User.
 *
 * @ORM\Entity
 * @ORM\Table(name="users")
 * @ORM\InheritanceType("JOINED")
 * @ORM\DiscriminatorColumn(name="user_type", type="string")
 * @ORM\DiscriminatorMap({
 *      "person"="Person",
 *      "staff"="Staff"
 * })
 *
 * @CustomIndexAnnotation\CustomIndexes(indexes={
 *     @CustomIndexAnnotation\CustomIndex(name="gin_email_index", columns={"email gin_trgm_ops"}, using="gin")
 * })
 */
abstract class User
{
    /**
     * @var string
     *
     * @ORM\Column(type="string", unique=true)
     */
    protected $email;
}

/**
 * Class Person.
 */
class Person extends User
{
}

/**
 * Class Staff.
 */
class Staff extends User
{
}
```