### PR TITLE
Resolve #7: Add support for Symfony 4.x

### DIFF
--- a/DependencyInjection/IntaroCustomIndexExtension.php
+++ b/DependencyInjection/IntaroCustomIndexExtension.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -19,6 +20,9 @@ class IntaroCustomIndexExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
+        $loader = new XmlFileLoader($container, new FileLocator(dirname(__DIR__).'/Resources/config'));
+        $loader->load('services.xml');
+
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="intaro_custom_index.command.index_update_command" class="\Intaro\CustomIndexBundle\Command\IndexUpdateCommand">
+            <tag name="console.command" command="intaro:doctrine:index:update" />
+        </service>
+    </services>
+</container>

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "require": {
         "php": ">=5.4.0",
         "doctrine/orm": "^2.2.3",
-        "symfony/config": "^2.1 || ^3.0",
-        "symfony/console": "^2.1 || ^3.0",
-        "symfony/dependency-injection": "^2.1 || ^3.0",
-        "symfony/http-kernel": "^2.1 || ^3.0",
-        "symfony/validator": "^2.1 || ^3.0"
+        "symfony/config": "^2.1 || ^3.0 || ^4.0",
+        "symfony/console": "^2.1 || ^3.0 || ^4.0",
+        "symfony/dependency-injection": "^2.1 || ^3.0 || ^4.0",
+        "symfony/http-kernel": "^2.1 || ^3.0 || ^4.0",
+        "symfony/validator": "^2.1 || ^3.0 || ^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Changes made:
 - Bump `composer.json` constrains to support 4.x
 - Register command and make it lazy (since 3.4 they are not autoregistered)