### PR TITLE
Configurable list of allowed index types

### DIFF
--- a/DBAL/Schema/CustomIndex.php
+++ b/DBAL/Schema/CustomIndex.php
@@ -2,6 +2,7 @@
 
 namespace Intaro\CustomIndexBundle\DBAL\Schema;
 
+use Intaro\CustomIndexBundle\Validator\Constraints\AllowedIndexType;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Constraints as Assert;
 use Doctrine\DBAL\Connection;
@@ -13,8 +14,6 @@ class CustomIndex
     const PREFIX = 'i_cindex_';
 
     const UNIQUE = 'unique';
-
-    protected static $availableUsingMethods = ['btree', 'hash', 'gin', 'gist'];
 
     protected static $currentSchema;
 
@@ -52,9 +51,7 @@ class CustomIndex
             'max'           => 63,
             'maxMessage'    => 'Name is too long',
         ]));
-        $metadata->addPropertyConstraint('using', new Assert\Choice([
-            'choices'       => self::$availableUsingMethods,
-        ]));
+        $metadata->addPropertyConstraint('using', new AllowedIndexType());
         $metadata->addPropertyConstraint('columns', new Assert\Count([
             'min'           => 1,
             'minMessage'    => "You must specify at least one column",

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -8,6 +8,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    protected static $availableIndexTypes = ['btree', 'hash', 'gin', 'gist'];
+
     /**
      * {@inheritDoc}
      */
@@ -22,6 +24,16 @@ class Configuration implements ConfigurationInterface
                 // else update only in current schema
                 ->booleanNode('search_in_all_schemas')
                     ->defaultTrue()
+                ->end()
+                ->arrayNode('allowed_index_types')
+                    ->prototype('scalar')
+                        ->validate()
+                            ->ifNotInArray(self::$availableIndexTypes)
+                            ->thenInvalid("Unknown index type. Allowed types: ".implode(', ', self::$availableIndexTypes).".")
+                        ->end()
+                    ->end()
+                    ->cannotBeEmpty()
+                    ->defaultValue(self::$availableIndexTypes)
                 ->end()
             ->end();
 

--- a/DependencyInjection/IntaroCustomIndexExtension.php
+++ b/DependencyInjection/IntaroCustomIndexExtension.php
@@ -30,5 +30,9 @@ class IntaroCustomIndexExtension extends Extension
             'intaro.custom_index.search_in_all_schemas',
             $config['search_in_all_schemas']
         );
+        $container->setParameter(
+            'intaro.custom.index.allowed_index_types',
+            $config['allowed_index_types']
+        );
     }
 }

--- a/README.md
+++ b/README.md
@@ -33,12 +33,16 @@ If your project have many schemas in single database and command must generate c
 ```yaml
 intaro_custom_index:
     search_in_all_schemas: false
+    allowed_index_types: ['gin', 'gist', 'btree', 'hash']
 
 ```
 
 Default value of `search_in_all_schemas` is `true`.
 If you have different entities in different schemas and you need to update custom indexes in all schemas at once then you must set `search_in_all_schemas` to `true` or omit this config.
 If you have database with only public schema then `search_in_all_schemas` value doesn't matter.
+
+Parameter `allowed_index_types` helps to exclude some types of indexes. If someone will try to use excluded type, command `intaro:doctrine:index:update` will return an error.  
+Default value is `['gin', 'gist', 'btree', 'hash']`.
 
 ## Usage
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,5 +8,10 @@
         <service id="intaro_custom_index.command.index_update_command" class="Intaro\CustomIndexBundle\Command\IndexUpdateCommand">
             <tag name="console.command" command="intaro:doctrine:index:update" />
         </service>
+
+        <service id="intaro_custom_index.allowed_index_type_validator" class="Intaro\CustomIndexBundle\Validator\Constraints\AllowedIndexTypeValidator">
+            <argument>%intaro.custom.index.allowed_index_types%</argument>
+            <tag name="validator.constraint_validator" />
+        </service>
     </services>
 </container>

--- a/Validator/Constraints/AllowedIndexType.php
+++ b/Validator/Constraints/AllowedIndexType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Intaro\CustomIndexBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ */
+class AllowedIndexType extends Constraint
+{
+    public $message = 'Index type {{ type }} is not allowed. List of allowed types: {{ allowed_types }}.';
+
+    public function validatedBy()
+    {
+        return \get_class($this).'Validator';
+    }
+}

--- a/Validator/Constraints/AllowedIndexTypeValidator.php
+++ b/Validator/Constraints/AllowedIndexTypeValidator.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Intaro\CustomIndexBundle\Validator\Constraints;
+
+use Intaro\CustomIndexBundle\Validator\Constraints\AllowedIndexType;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class AllowedIndexTypeValidator extends ConstraintValidator
+{
+    private static $constraintClass = 'Intaro\CustomIndexBundle\Validator\Constraints\AllowedIndexType';
+
+    /**
+     * @var string[]
+     */
+    protected $allowedIndexTypes;
+
+    /**
+     * @param string[] $allowedIndexTypes
+     */
+    public function __construct(array $allowedIndexTypes)
+    {
+        $this->allowedIndexTypes = $allowedIndexTypes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof AllowedIndexType) {
+            throw new UnexpectedTypeException($constraint, self::$constraintClass);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        if (!in_array($value, $this->allowedIndexTypes)) {
+            $this->context->addViolation(
+                $constraint->message,
+                [
+                    '{{ type }}' => $value,
+                    '{{ allowed_types }}' => implode(', ', $this->allowedIndexTypes),
+                ]
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a field `allowed_index_types` to bundle's configuration.

That parameter helps to exclude some types of indexes. If someone will try to use excluded type, command `intaro:doctrine:index:update` will return an error.  

Default value is `['gin', 'gist', 'btree', 'hash']`.