### PR TITLE
intaro#13: Add support for Symfony 5.x

### DIFF
--- a/Command/IndexUpdateCommand.php
+++ b/Command/IndexUpdateCommand.php
@@ -80,6 +80,8 @@ class IndexUpdateCommand extends Command
         if (!$createFlag) {
             $this->output->writeln("<info>No index was created</info>");
         }
+
+        return 0;
     }
 
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,8 +15,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('intaro_custom_index');
+        $treeBuilder = new TreeBuilder('intaro_custom_index');
+        $rootNode = \method_exists($treeBuilder, 'getRootNode')
+            ? $treeBuilder->getRootNode() : $treeBuilder->root('intaro_custom_index');
 
         $rootNode
             ->children()

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "require": {
         "php": ">=5.4.0",
         "doctrine/orm": "^2.2.3",
-        "symfony/config": "^2.1 || ^3.0 || ^4.0",
-        "symfony/console": "^2.1 || ^3.0 || ^4.0",
-        "symfony/dependency-injection": "^2.1 || ^3.0 || ^4.0",
-        "symfony/http-kernel": "^2.1 || ^3.0 || ^4.0",
-        "symfony/validator": "^2.1 || ^3.0 || ^4.0"
+        "symfony/config": "^2.1 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/console": "^2.1 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/dependency-injection": "^2.1 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/http-kernel": "^2.1 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/validator": "^2.1 || ^3.0 || ^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
See #13 

- Symfony 5 errors out if commands don't return integers, `0` should be returned for success for very long time
- `TreeBuilder` now has more streamlined API, added shim
- Updated `composer.json`