### PR TITLE
Exclude temp concurrent indexes %_ccnew from query of current indexes

### DIFF
--- a/DBAL/ExtendedPlatform.php
+++ b/DBAL/ExtendedPlatform.php
@@ -42,7 +42,12 @@ final class ExtendedPlatform extends PostgreSQLPlatform
 
     public function indexesNamesSelectSQL(bool $searchInAllSchemas): string
     {
-        $sql = "SELECT schemaname || '.' || indexname as relname FROM pg_indexes WHERE indexname LIKE :indexName";
+        $sql = "
+            SELECT schemaname || '.' || indexname as relname 
+            FROM pg_indexes 
+            WHERE indexname LIKE :indexName
+            AND indexname NOT LIKE '%_ccnew'
+        ";
         if (!$searchInAllSchemas) {
             $sql .= " AND schemaname = current_schema()";
         }


### PR DESCRIPTION
Command `intaro:doctrine:index:update` drop internal temporal indexes with suffix `_ccnew` that used [in concurrent reindex](https://www.postgresql.org/docs/current/sql-reindex.html#SQL-REINDEX-CONCURRENTLY) or creating index. This may result locking or crashes reindex